### PR TITLE
style: apply rustfmt and Clippy fixes across codebase

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,8 +1,8 @@
-use anyhow::Result;
-use uuid::Uuid;
 use crate::context;
 use crate::db::DbConnection;
 use crate::models::Todo;
+use anyhow::Result;
+use uuid::Uuid;
 
 pub async fn execute(
     db: &DbConnection,
@@ -18,42 +18,43 @@ pub async fn execute(
         .unwrap_or_default();
 
     // Auto-detect context if not provided
-    let project = project.or_else(|| context::detect_project());
-    let file_path = file_path.or_else(|| context::detect_file_path());
+    let project = project.or_else(context::detect_project);
+    let file_path = file_path.or_else(context::detect_file_path);
 
     let mut created_todos = Vec::new();
 
     for task in content {
         let uuid = Uuid::new_v4().to_string();
-        
+
         // Build query dynamically based on optional fields
         let mut query = String::from("CREATE todo SET uuid = $uuid, content = $content, status = 'pending', priority = $priority, tags = $tags");
-        
+
         if project.is_some() {
             query.push_str(", project = $project");
         }
-        
+
         if file_path.is_some() {
             query.push_str(", file_path = $file_path");
         }
-        
-        let mut query_builder = db.query(&query)
+
+        let mut query_builder = db
+            .query(&query)
             .bind(("uuid", uuid))
             .bind(("content", task))
             .bind(("priority", priority))
             .bind(("tags", tag_list.clone()));
-            
+
         if let Some(ref proj) = project {
             query_builder = query_builder.bind(("project", proj.clone()));
         }
-        
+
         if let Some(ref fp) = file_path {
             query_builder = query_builder.bind(("file_path", fp.clone()));
         }
-        
+
         let mut result = query_builder.await?;
         let created: Option<Todo> = result.take(0)?;
-        
+
         if let Some(todo) = created {
             created_todos.push(todo);
         }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, Result};
-use chrono::Utc;
 use crate::commands::normalize_id;
 use crate::db::DbConnection;
 use crate::models::{Todo, TodoStatus};
+use anyhow::{anyhow, Result};
+use chrono::Utc;
 
 pub async fn execute(db: &DbConnection, ids: Vec<String>) -> Result<usize> {
     let mut completed_count = 0;
@@ -14,11 +14,11 @@ pub async fn execute(db: &DbConnection, ids: Vec<String>) -> Result<usize> {
         let query = format!("SELECT * FROM {} LIMIT 1", record_id);
         let mut result = db.query(&query).await?;
         let todos: Vec<Todo> = result.take(0)?;
-        
+
         if todos.is_empty() {
             return Err(anyhow!("Todo not found: {}", record_id));
         }
-        
+
         let mut todo = todos.into_iter().next().unwrap();
 
         // Update status and completed_at
@@ -32,7 +32,7 @@ pub async fn execute(db: &DbConnection, ids: Vec<String>) -> Result<usize> {
             record_id
         );
         db.query(&update_query).await?;
-        
+
         completed_count += 1;
     }
 

--- a/src/commands/due.rs
+++ b/src/commands/due.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, Result};
-use chrono::{DateTime, NaiveDate, Utc};
 use crate::commands::normalize_id;
 use crate::db::DbConnection;
 use crate::models::Todo;
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, NaiveDate, Utc};
 
 pub async fn execute(db: &DbConnection, id: String, due_date: Option<String>) -> Result<()> {
     let record_id = normalize_id(id);

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,6 +1,6 @@
-use anyhow::Result;
 use crate::db::DbConnection;
 use crate::models::Todo;
+use anyhow::Result;
 
 pub async fn execute(
     db: &DbConnection,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,8 @@
 pub mod add;
-pub mod list;
 pub mod complete;
-pub mod remove;
 pub mod due;
+pub mod list;
+pub mod remove;
 pub mod undo;
 
 /// Normalize a todo ID to the `todo:<id>` record format.

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -1,7 +1,7 @@
-use anyhow::{anyhow, Result};
 use crate::commands::normalize_id;
 use crate::db::DbConnection;
 use crate::models::Todo;
+use anyhow::{anyhow, Result};
 
 pub async fn execute(db: &DbConnection, ids: Vec<String>) -> Result<usize> {
     let mut removed_count = 0;

--- a/src/commands/undo.rs
+++ b/src/commands/undo.rs
@@ -1,7 +1,7 @@
-use anyhow::{anyhow, Result};
 use crate::commands::normalize_id;
 use crate::db::DbConnection;
 use crate::models::{Todo, TodoStatus};
+use anyhow::{anyhow, Result};
 
 pub async fn execute(db: &DbConnection, ids: Vec<String>) -> Result<usize> {
     let mut undone_count = 0;

--- a/src/context/git.rs
+++ b/src/context/git.rs
@@ -14,7 +14,7 @@ pub fn detect_project() -> Option<String> {
     // Examples:
     //   git@github.com:user/project.git -> project
     //   https://github.com/user/project -> project
-    let name = url.split('/').last()?.trim_end_matches(".git");
+    let name = url.split('/').next_back()?.trim_end_matches(".git");
 
     Some(name.to_string())
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,4 +1,4 @@
 pub mod git;
 
-pub use git::detect_project;
 pub use git::detect_file_path;
+pub use git::detect_project;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,9 +1,9 @@
 pub mod schema;
 
 use anyhow::Result;
+use std::path::PathBuf;
 use surrealdb::engine::local::{Db, RocksDb};
 use surrealdb::Surreal;
-use std::path::PathBuf;
 
 // Type alias for the database connection
 pub type DbConnection = Surreal<Db>;

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -3,7 +3,8 @@ use surrealdb::engine::local::Db;
 use surrealdb::Surreal;
 
 pub async fn initialize(db: &Surreal<Db>) -> Result<()> {
-    db.query(r#"
+    db.query(
+        r#"
         DEFINE TABLE IF NOT EXISTS todo SCHEMAFULL;
         DEFINE FIELD IF NOT EXISTS uuid ON TABLE todo TYPE string;
         DEFINE FIELD IF NOT EXISTS content ON TABLE todo TYPE string;
@@ -22,7 +23,9 @@ pub async fn initialize(db: &Surreal<Db>) -> Result<()> {
 
         DEFINE INDEX IF NOT EXISTS idx_status ON TABLE todo COLUMNS status;
         DEFINE INDEX IF NOT EXISTS idx_project ON TABLE todo COLUMNS project;
-    "#).await?;
+    "#,
+    )
+    .await?;
 
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,6 @@ impl ExitCode {
             ExitCode::TodoNotFound
         } else if msg.contains("invalid") {
             ExitCode::InvalidInput
-        } else if msg.contains("database") {
-            ExitCode::DatabaseError
         } else {
             ExitCode::DatabaseError
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,15 @@ async fn run() -> Result<()> {
 
     match cli.command {
         Commands::Todo { action } => match action {
-            TodoAction::Add { content, priority, project, file, tags } => {
-                let todos = commands::add::execute(&db, content, priority, project, file, tags).await?;
+            TodoAction::Add {
+                content,
+                priority,
+                project,
+                file,
+                tags,
+            } => {
+                let todos =
+                    commands::add::execute(&db, content, priority, project, file, tags).await?;
 
                 for todo in &todos {
                     println!("✓ Created todo: {}", todo.content);
@@ -33,7 +40,11 @@ async fn run() -> Result<()> {
 
                 Ok(())
             }
-            TodoAction::List { status, project, limit } => {
+            TodoAction::List {
+                status,
+                project,
+                limit,
+            } => {
                 let todos = commands::list::execute(&db, status, project, limit).await?;
 
                 if cli.json {

--- a/tests/add_test.rs
+++ b/tests/add_test.rs
@@ -14,15 +14,13 @@ async fn test_add_single_todo() {
         None,
         None,
         None,
-    ).await;
+    )
+    .await;
 
     assert!(result.is_ok());
 
     // Query database to verify
-    let todos: Vec<doob::models::Todo> = db
-        .select("todo")
-        .await
-        .expect("Failed to query todos");
+    let todos: Vec<doob::models::Todo> = db.select("todo").await.expect("Failed to query todos");
 
     assert_eq!(todos.len(), 1);
     assert_eq!(todos[0].content, "Fix auth bug");
@@ -36,12 +34,17 @@ async fn test_add_batch_todos() {
 
     let result = doob::commands::add::execute(
         &db,
-        vec!["Task 1".to_string(), "Task 2".to_string(), "Task 3".to_string()],
+        vec![
+            "Task 1".to_string(),
+            "Task 2".to_string(),
+            "Task 3".to_string(),
+        ],
         Some(2),
         None,
         None,
         Some("urgent,test".to_string()),
-    ).await;
+    )
+    .await;
 
     assert!(result.is_ok());
     let created = result.unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,7 @@
 use doob::db::{create_connection, DbConnection};
 
 pub async fn setup_test_db() -> DbConnection {
-    create_connection(None).await.expect("Failed to create test DB")
+    create_connection(None)
+        .await
+        .expect("Failed to create test DB")
 }

--- a/tests/complete_test.rs
+++ b/tests/complete_test.rs
@@ -8,7 +8,9 @@ async fn test_complete_single_todo() {
     let db = setup_test_db().await;
 
     // Create a todo
-    doob::commands::add::execute(&db, vec!["Test".to_string()], None, None, None, None).await.unwrap();
+    doob::commands::add::execute(&db, vec!["Test".to_string()], None, None, None, None)
+        .await
+        .unwrap();
 
     // Get the ID
     let todos: Vec<doob::models::Todo> = db.select("todo").await.unwrap();
@@ -43,11 +45,16 @@ async fn test_complete_batch_todos() {
         None,
         None,
         None,
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
     // Get IDs
     let todos: Vec<doob::models::Todo> = db.select("todo").await.unwrap();
-    let ids: Vec<String> = todos.iter().map(|t| t.id.clone().unwrap().to_string()).collect();
+    let ids: Vec<String> = todos
+        .iter()
+        .map(|t| t.id.clone().unwrap().to_string())
+        .collect();
 
     // Complete all
     let result = doob::commands::complete::execute(&db, ids).await;

--- a/tests/context_integration_test.rs
+++ b/tests/context_integration_test.rs
@@ -1,10 +1,10 @@
 mod common;
 
+use doob::commands::add;
+use doob::db;
+use git2::Repository;
 use std::env;
 use tempfile::TempDir;
-use git2::Repository;
-use doob::db;
-use doob::commands::add;
 
 #[tokio::test]
 #[cfg_attr(not(feature = "no_parallel"), serial_test::serial)]
@@ -16,7 +16,8 @@ async fn test_context_detection_integration() {
     let repo = Repository::init(repo_path).unwrap();
 
     // Add remote
-    repo.remote("origin", "git@github.com:user/my-project.git").unwrap();
+    repo.remote("origin", "git@github.com:user/my-project.git")
+        .unwrap();
 
     // Change to repo directory
     let original_dir = env::current_dir().unwrap();
@@ -33,7 +34,9 @@ async fn test_context_detection_integration() {
         None, // No project provided
         None, // No file_path provided
         None,
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
     assert_eq!(todos.len(), 1);
     assert_eq!(todos[0].project, Some("my-project".to_string()));
@@ -47,7 +50,9 @@ async fn test_context_detection_integration() {
         Some("explicit-project".to_string()),
         None,
         None,
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
     assert_eq!(todos.len(), 1);
     assert_eq!(todos[0].project, Some("explicit-project".to_string()));
@@ -64,7 +69,8 @@ async fn test_file_path_detection() {
 
     // Initialize git repo
     let repo = Repository::init(repo_path).unwrap();
-    repo.remote("origin", "git@github.com:user/test-repo.git").unwrap();
+    repo.remote("origin", "git@github.com:user/test-repo.git")
+        .unwrap();
 
     // Create subdirectory
     let sub_dir = repo_path.join("src").join("components");
@@ -85,7 +91,9 @@ async fn test_file_path_detection() {
         None,
         None,
         None,
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
     assert_eq!(todos.len(), 1);
     assert_eq!(todos[0].project, Some("test-repo".to_string()));

--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -1,8 +1,8 @@
 mod common;
 
+use git2::Repository;
 use std::env;
 use tempfile::TempDir;
-use git2::Repository;
 
 #[tokio::test]
 async fn test_detect_project_from_git() {
@@ -13,7 +13,8 @@ async fn test_detect_project_from_git() {
     let repo = Repository::init(repo_path).unwrap();
 
     // Add remote
-    repo.remote("origin", "git@github.com:user/test-project.git").unwrap();
+    repo.remote("origin", "git@github.com:user/test-project.git")
+        .unwrap();
 
     // Change to repo directory
     let original_dir = env::current_dir().unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,7 +21,9 @@ async fn test_complete_workflow() {
 
     // Complete it
     let id = todos[0].id.clone().unwrap().to_string();
-    let count = doob::commands::complete::execute(&db, vec![id]).await.unwrap();
+    let count = doob::commands::complete::execute(&db, vec![id])
+        .await
+        .unwrap();
     assert_eq!(count, 1);
 
     // List again

--- a/tests/json_output_test.rs
+++ b/tests/json_output_test.rs
@@ -8,10 +8,21 @@ async fn test_json_output_format() {
     let db = setup_test_db().await;
 
     // Add todos
-    doob::commands::add::execute(&db, vec!["Test 1".to_string()], Some(1), None, None, Some("urgent".to_string())).await.unwrap();
+    doob::commands::add::execute(
+        &db,
+        vec!["Test 1".to_string()],
+        Some(1),
+        None,
+        None,
+        Some("urgent".to_string()),
+    )
+    .await
+    .unwrap();
 
     // Get todos
-    let todos = doob::commands::list::execute(&db, None, None, None).await.unwrap();
+    let todos = doob::commands::list::execute(&db, None, None, None)
+        .await
+        .unwrap();
 
     // Format as JSON
     let json = doob::output::json::format_todos(&todos);

--- a/tests/list_output_test.rs
+++ b/tests/list_output_test.rs
@@ -14,19 +14,18 @@ async fn test_list_output_formatting() {
         Some("Project A".to_string()),
         None,
         Some("urgent,backend".to_string()),
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
-    doob::commands::add::execute(
-        &db,
-        vec!["Task 2".to_string()],
-        Some(2),
-        None,
-        None,
-        None,
-    ).await.unwrap();
+    doob::commands::add::execute(&db, vec!["Task 2".to_string()], Some(2), None, None, None)
+        .await
+        .unwrap();
 
     // Get and format todos
-    let todos = doob::commands::list::execute(&db, None, None, None).await.unwrap();
+    let todos = doob::commands::list::execute(&db, None, None, None)
+        .await
+        .unwrap();
     let output = doob::output::format_human(&todos);
 
     // Verify output contains expected elements
@@ -43,7 +42,9 @@ async fn test_list_output_formatting() {
 async fn test_list_empty() {
     let db = setup_test_db().await;
 
-    let todos = doob::commands::list::execute(&db, None, None, None).await.unwrap();
+    let todos = doob::commands::list::execute(&db, None, None, None)
+        .await
+        .unwrap();
     let output = doob::output::format_human(&todos);
 
     assert_eq!(output, "No todos found");

--- a/tests/list_test.rs
+++ b/tests/list_test.rs
@@ -15,7 +15,9 @@ async fn test_list_all_todos() {
         None,
         None,
         None,
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
     // Test list
     let todos = doob::commands::list::execute(&db, None, None, None).await;
@@ -30,18 +32,26 @@ async fn test_list_filter_by_status() {
     let db = setup_test_db().await;
 
     // Add todos
-    doob::commands::add::execute(&db, vec!["Task 1".to_string()], None, None, None, None).await.unwrap();
+    doob::commands::add::execute(&db, vec!["Task 1".to_string()], None, None, None, None)
+        .await
+        .unwrap();
 
     // Complete one
     let todos: Vec<doob::models::Todo> = db.select("todo").await.unwrap();
     let todo_id = todos[0].id.clone().unwrap().to_string();
-    doob::commands::complete::execute(&db, vec![todo_id]).await.unwrap();
+    doob::commands::complete::execute(&db, vec![todo_id])
+        .await
+        .unwrap();
 
     // Add another pending
-    doob::commands::add::execute(&db, vec!["Task 2".to_string()], None, None, None, None).await.unwrap();
+    doob::commands::add::execute(&db, vec!["Task 2".to_string()], None, None, None, None)
+        .await
+        .unwrap();
 
     // List only pending
-    let pending = doob::commands::list::execute(&db, Some("pending".to_string()), None, None).await.unwrap();
+    let pending = doob::commands::list::execute(&db, Some("pending".to_string()), None, None)
+        .await
+        .unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].content, "Task 2");
 }


### PR DESCRIPTION
## Summary

- Reorder imports to follow rustfmt conventions
- Normalize trailing whitespace and blank lines; break long lines to default line-width
- Remove a redundant dead-code branch in `src/error.rs`
- Apply minor idiomatic improvements (`or_else` fn-pointer form, prefer `Iterator::next_back` over `last`)

No functional changes — formatting and lint cleanup only.

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code organization improvements and formatting standardization across the codebase.
  * Streamlined error handling logic for improved clarity.
  * Import statement consolidation and reordering.

* **Tests**
  * Updated test formatting for consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->